### PR TITLE
Add option to provide other app_name for scope check

### DIFF
--- a/lib/zaikio/jwt_auth.rb
+++ b/lib/zaikio/jwt_auth.rb
@@ -27,8 +27,8 @@ module Zaikio
         @authorize_by_jwt_subject_type ||= type
       end
 
-      def authorize_by_jwt_scopes(scopes = nil)
-        @authorize_by_jwt_scopes ||= scopes
+      def authorize_by_jwt_scopes(scopes = nil, options = {})
+        @authorize_by_jwt_scopes ||= options.merge(scopes: scopes)
       end
     end
 
@@ -65,9 +65,8 @@ module Zaikio
       end
 
       def show_error_if_authorize_by_jwt_scopes_fails(token_data)
-        if !self.class.authorize_by_jwt_scopes || token_data.scope?(self.class.authorize_by_jwt_scopes, action_name)
-          return
-        end
+        scope_data = self.class.authorize_by_jwt_scopes
+        return if !scope_data[:scopes] || token_data.scope?(scope_data[:scopes], action_name, scope_data[:app_name])
 
         render_error("unpermitted_scope")
       end

--- a/lib/zaikio/jwt_auth/token_data.rb
+++ b/lib/zaikio/jwt_auth/token_data.rb
@@ -33,11 +33,12 @@ module Zaikio
         @payload["jti"]
       end
 
-      def scope?(allowed_scopes, action_name)
+      def scope?(allowed_scopes, action_name, app_name = nil)
+        app_name ||= Zaikio::JWTAuth.configuration.app_name
         Array(allowed_scopes).map(&:to_s).any? do |allowed_scope|
           scope.any? do |s|
             parts = s.split(".")
-            parts[0] == Zaikio::JWTAuth.configuration.app_name &&
+            parts[0] == app_name &&
               parts[1] == allowed_scope &&
               action_in_permission?(action_name, parts[2])
           end

--- a/test/zaikio/jwt_auth_test.rb
+++ b/test/zaikio/jwt_auth_test.rb
@@ -62,6 +62,18 @@ class ResourcesController < ApplicationController
   end
 end
 
+class OtherAppResourcesController < ApplicationController
+  include Zaikio::JWTAuth
+
+  before_action :authenticate_by_jwt
+
+  authorize_by_jwt_scopes :organization, app_name: "directory"
+
+  def index
+    render plain: "hello"
+  end
+end
+
 class ResourcesControllerTest < ActionDispatch::IntegrationTest
   def setup
     Zaikio::JWTAuth.configure do |config|
@@ -74,6 +86,7 @@ class ResourcesControllerTest < ActionDispatch::IntegrationTest
 
     Rails.application.routes.draw do
       resources :resources
+      resources :other_app_resources
     end
   end
 
@@ -141,5 +154,20 @@ class ResourcesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "123", scope.id
     audience = controller.instance_variable_get(:@audience)
     assert_equal "directory", audience
+  end
+
+  test "successful if correct JWT was passed with other app name" do
+    token = generate_token
+    get "/other_app_resources", headers: { "Authorization" => "Bearer #{token}" }
+    assert_response :success
+  end
+
+  test "forbissen if correct JWT was passed with wrong app name" do
+    token = generate_token(
+      scope: ["test_app.organization.r"]
+    )
+    get "/other_app_resources", headers: { "Authorization" => "Bearer #{token}" }
+    assert_response :forbidden
+    assert_equal({ "errors" => ["unpermitted_scope"] }.to_json, response.body)
   end
 end


### PR DESCRIPTION
Allows a developer to include the gem and support multiple apps with scope protection.